### PR TITLE
fix: included app/*.js for componentjs package

### DIFF
--- a/src/Development/Duplo/Scripts.hs
+++ b/src/Development/Duplo/Scripts.hs
@@ -42,6 +42,7 @@ build config = \ out -> do
 
   -- These paths need to be expanded by Shake
   let dynamicPaths = [ "app/modules//*.js"
+                     , "components/*/app//*.js"
                      , "components/*/app/modules//*.js"
                      -- Compile dev files in dev mode as well.
                      ] ++ if   C.isInDev config


### PR DESCRIPTION
fixed these below cases:
- `bootloader`, its structure like: `app/index.js` rather than `app/modules/*_/_.js
- `sdk`, there are two js file `index.js` and `type.js` in the `app` directory

/cc @kenhkan
