### PR TITLE
fix Non-exhaustive patterns in case

### DIFF
--- a/src/Development/Duplo/Markups.hs
+++ b/src/Development/Duplo/Markups.hs
@@ -50,7 +50,7 @@ build config = \ out -> do
   let absPaths       = case env of
                          "dev"  -> [ devCodePath ]
                          "test" -> [ testPath ]
-                         ""     -> []
+                         _      -> []
                        ++ map (cwd </>) allPaths
 
   -- Merge both types of paths

--- a/src/Development/Duplo/Scripts.hs
+++ b/src/Development/Duplo/Scripts.hs
@@ -54,7 +54,7 @@ build config = \ out -> do
   let staticPaths = case env of
                       "dev"  -> [ "dev/index" ]
                       "test" -> [ "test/index"]
-                      ""     -> []
+                      _      -> []
                     ++ [ "app/index" ]
 
   -- These paths need to be expanded by Shake.
@@ -63,7 +63,7 @@ build config = \ out -> do
   let dynamicPaths = case env of
                        "dev"  -> [ "dev/modules" ]
                        "test" -> [ "test/modules"]
-                       ""     -> []
+                       _      -> []
                      -- Then normal scripts
                      ++ [ "app/modules" ]
                      -- Build list only for dependencies.


### PR DESCRIPTION
hey @kenhkan, I got this error print when i build embed just now:

```
src/Development/Duplo/Markups.hs:(50,24)-(53,37): Non-exhaustive patterns in case
```

sorry, this should be introduced by my last PR, now fixed this in this patch :cherries: 
