### PR TITLE
components: fix expired depIds

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -139,6 +139,9 @@ main = do
 
   -- We may need custom builds with mode
   let depManifestPath = cwd </> "component.json"
+
+  -- TODO(Yorkie): to be remove if verified by @Kenneth
+  -- because the depIds is unnecessary in config
   dependencies <- CM.getDependencies $ case duploMode of
                                          "" -> Nothing
                                          a  -> Just a

--- a/src/Development/Duplo/Scripts.hs
+++ b/src/Development/Duplo/Scripts.hs
@@ -54,11 +54,13 @@ build config out = do
   -- Preconditions
   lift $ createIntermediaryDirectories devCodePath
 
-  -- get depIds dynamicly
+  -- Get dependencies dynamically to avoid removed dependencies to be
+  -- included again, when reloading during development.
   dependencies <- liftIO $ CM.getDependencies $ case mode of
                                               "" -> Nothing
                                               a  -> Just a
-  let depIds = map (\dep -> unpack $ replace "/" "-" (pack dep)) dependencies
+  let makeDepId = unpack . replace "/" "-" . pack
+  let depIds = map makeDepId dependencies
 
   -- These paths don't need to be expanded.
   let staticPaths = case buildMode of


### PR DESCRIPTION
even though we updates components folder, but the depIds is expired
because this is writtern in making config. fix the issue by getting
depIds before building scripts.

more details:
this issue causes the build would lose the components source if we have an incomplete `./components` structure. to reproduce the bug, remove the directory `./components` and run any build, then go through and check if the components source is included in generated `index.js`.

actually that's just because the `config._dependencies` is set in CLI.hs, it's in front of `Scripts.hs` even though we would have installed the `components` at that moment.

btw, another reason is that we would get `depIds` from real directory rather than the static `components.json`, this is of course required for sub-modules, just state this to clear the issue better :cherries: 

/cc @kenhkan 