### PR TITLE
only search /components in $util/find.sh

### DIFF
--- a/src/Development/Duplo/Component.hs
+++ b/src/Development/Duplo/Component.hs
@@ -104,7 +104,7 @@ appInfoToVersion appInfo = (AI.name appInfo, AI.version appInfo)
 -- | Given a path, find all the `component.json`s
 getAllManifestPaths :: FilePath -> FilePath -> Action [FilePath]
 getAllManifestPaths utilPath root = do
-    Stdout out <- command [] (utilPath </> "find.sh") [root, manifestName]
+    Stdout out <- command [] (utilPath </> "find.sh") [root </> "components", manifestName]
     return $ lines out
 
 -- | Get the component dependency list by providing a mode, or not.


### PR DESCRIPTION
to reproduce this issue:

1. `npm install async`
2. because async has `components.json` therefor it'd print the following error:

```
Command: /Users/yorkie/workspace/pixbi/duplo/dist/build/duplo/../../../util/scripts-optimize.sh
The manifest file `/Users/yorkie/workspace/pixbi/indesign-plugin/node_modules/archiver/node_modules/async/component.json` is not a valid duplo JSON.)
```

I occurred this bug in adding `sdk` to `pixbi/indesign-plugin` that repo is just a nodejs project, where the `node_modules` directory is required, so fixed by doing search only the `/components` :-)

/cc @kenhkan 