### PR TITLE
fix missing ./component.json by previous fix

### DIFF
--- a/src/Development/Duplo/Component.hs
+++ b/src/Development/Duplo/Component.hs
@@ -85,7 +85,7 @@ extractCompVersions config = do
     let toVersion path'   = appInfoToVersion . decodeManifest path' . BS.pack
     let takeVersion path' = liftM (toVersion path') (readFile path')
     -- Go through it
-    manifests <- mapM (liftIO . takeVersion) paths
+    manifests <- mapM (liftIO . takeVersion) (paths ++ ["./component.json"])
     -- Marshalling
     return $ BS.unpack $ encode $ fromList manifests
 


### PR DESCRIPTION
Sorry, this bug is caused by my previous commit: e678d727671e5408b10fa87e681798ce4985160e, we forgot to add `./component.json` for build variable `DUPLO_VERSIONS`, which would break the embed or any other sdk-based project, it's awful...fixed for now :cherries: 

/cc @kenhkan 