### PR TITLE
Script: fix uglify bug

### DIFF
--- a/src/Development/Duplo/Scripts.hs
+++ b/src/Development/Duplo/Scripts.hs
@@ -96,11 +96,11 @@ build config out = do
   compVers <- lift $ extractCompVersions config
 
   -- Inject global/environment variables
-  let envVars = "var DUPLO_ENV = '" ++ env ++ "';\n"
+  let envVars = "window.DUPLO_ENV = '" ++ env ++ "';\n"
              -- Decode and parse in runtime to avoid having to deal with
              -- escaping.
-             ++ "var DUPLO_IN = JSON.parse(window.atob('" ++ duploIn ++ "') || '{}' );\n"
-             ++ "var DUPLO_VERSIONS = " ++ compVers ++ ";\n"
+             ++ "window.DUPLO_IN = JSON.parse(window.atob('" ++ duploIn ++ "') || '{}' );\n"
+             ++ "window.DUPLO_VERSIONS = " ++ compVers ++ ";\n"
 
   -- Configure the compiler
   let compiler = (util </>) $ case buildMode of


### PR DESCRIPTION
DUPLO_ENV/DUPLO_IN/etc should be in global variable `window` rather than
using keyword `var`.

The original way can work without `uglify`, but it shouldn't work when
using `uglify` to cut down the size of generated file, `uglify` would
change the variables, which are defined by the special keyword `var`, so
that we can't access those variable in later runtime.

To **reproduce** this bug, run `duplo build` with `DUPLO_ENV=production` or others that is not equal to `development` or `test`, then try to access to `DUPLO_ENV`/`DUPLO_IN`/etc. in javascript runtime, then it would show "XXX is undefined".

/cc @kenhkan 
